### PR TITLE
Rename HasBlock to NotifyNewBlocks, and make it accept multiple blocks

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -16,8 +16,6 @@ type Interface interface { // type Exchanger interface
 	// NotifyNewBlocks tells the exchange that new blocks are available and can be served.
 	NotifyNewBlocks(ctx context.Context, blocks ...blocks.Block) error
 
-	IsOnline() bool
-
 	io.Closer
 }
 

--- a/interface.go
+++ b/interface.go
@@ -13,9 +13,8 @@ import (
 type Interface interface { // type Exchanger interface
 	Fetcher
 
-	// TODO Should callers be concerned with whether the block was made
-	// available on the network?
-	HasBlock(context.Context, blocks.Block) error
+	// NotifyNewBlocks tells the exchange that new blocks are available and can be served.
+	NotifyNewBlocks(ctx context.Context, blocks ...blocks.Block) error
 
 	IsOnline() bool
 

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.1.0"
+  "version": "v0.2.0"
 }


### PR DESCRIPTION
The goal here is twofold:
- allows for batched handling of multiple blocks at once
- act as a noisy signal for the breaking change that Bitswap is not adding blocks in the blockstore itself anymore (see https://github.com/ipfs/go-bitswap/pull/571)